### PR TITLE
Add a package.json file for the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "javascript-route-matcher",
+  "version": "0.1.0",
+  "author": "\"Cowboy\" Ben Alman (http://benalman.com/)",
+  "description": "A simple route matching / url building utility. Intended to be included as part of a larger routing library.",
+  "main": "dist/ba-routematcher.js",
+  "directories": {
+    "dist": "dist",
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "grunt",
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cowboy/javascript-route-matcher.git"
+  },
+  "keywords": [
+    "uri",
+    "url",
+    "routes"
+  ],
+  "bugs": {
+    "url": "https://github.com/cowboy/javascript-route-matcher/issues"
+  },
+  "license": "MIT/GPLv2",
+  "homepage": "https://github.com/cowboy/javascript-route-matcher",
+  "devDependencies": {
+    "grunt": "^0.2.15"
+  }
+}


### PR DESCRIPTION
Not sure if this is desired, but I thought it would be good to add a package.json to specify the version of Grunt used with this library and to enable publishing the module on npm. This might be useful to a project that I'm working on, and I'm trying to avoid adding non-npm 3rd-party deps for organization's sake.
