### PR TITLE
Support for bower install & wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-bower-javascript-route-matcher",
+  "version": "0.1.0",
+  "main": "dist/ba-routematcher.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components",
+    "test"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-bower-javascript-route-matcher",
+  "name": "javascript-route-matcher",
   "version": "0.1.1",
   "main": "dist/ba-routematcher.js",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "test-bower-javascript-route-matcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/ba-routematcher.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-matcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "\"Cowboy\" Ben Alman (http://benalman.com/)",
   "description": "A simple route matching / url building utility. Intended to be included as part of a larger routing library.",
   "main": "dist/ba-routematcher.js",


### PR DESCRIPTION
@cowboy if you don't want this that's okay. It's probably a small issue.
We're using [wiredep](https://github.com/taptapship/wiredep) via [a grunt plugin](https://github.com/stephenplusplus/grunt-wiredep) that came with the [angular-fullstack-generator](https://github.com/DaftMonk/generator-angular-fullstack) we used to kickstart our app.

After running `bower install` and then `grunt build` (or **server**, or whatever includes the **wiredep** task), anything listed in our bower.json that includes a 'main' field will get automatically inserted into a section of our html files. So we can have someone run `bower install` and magically scripts are in our page. It's sort of handy but not a make-or-break feature.

At any rate, without a bower.json that specifies a main in this package, that wiredep step won't work. So I think I added one + rev'd the version correctly. I think all you will have to do is update/push to github and bower will pick it up. 

I did it with [my fork of javascript-route-matcher](https://github.com/virtualandy/javascript-route-matcher) and it seemed to work with wiredep okay. Let me know if this PR needs cleanup or I can help in any other way. Thanks!
